### PR TITLE
Use utf8mb4 as default charset for table creating

### DIFF
--- a/api/src/main/java/cc/carm/lib/easysql/api/builder/TableCreateBuilder.java
+++ b/api/src/main/java/cc/carm/lib/easysql/api/builder/TableCreateBuilder.java
@@ -250,7 +250,7 @@ public interface TableCreateBuilder extends SQLBuilder {
                                      @Nullable ForeignKeyRule updateRule, @Nullable ForeignKeyRule deleteRule);
 
     default String defaultTablesSettings() {
-        return "ENGINE=InnoDB DEFAULT CHARSET=utf8";
+        return "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
     }
 
 }


### PR DESCRIPTION
Use utf8mb4 as default charset for table creating, this fixed the emoji related issues.